### PR TITLE
Add AssemblyAI streaming backend, local transcriber, and extension offscreen capture (v1.1.0)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -15,3 +15,53 @@ Task JSON from `shared/schemas/task.json`
 
 ## Output
 IssueStatus JSON matching `shared/schemas/issue_status.json`
+
+## Local meeting transcription websocket
+
+A lightweight local websocket server is available at `backend/meeting-audio-backend.js` for extension-driven live transcription with AssemblyAI Streaming (v3 websocket API).
+
+### Run
+
+```bash
+cd backend
+npm install
+ASSEMBLYAI_API_KEY=your_key_here npm start
+# optional
+# ASSEMBLYAI_SPEECH_MODEL=universal-streaming-multilingual npm start
+```
+
+The server listens on `ws://localhost:3001` (or `PORT` if set) and prints transcripts to stdout.
+
+## Local Node-only transcription (no Chrome extension)
+
+If you want to drop the extension and transcribe directly from local audio input, run:
+
+```bash
+cd backend
+ASSEMBLYAI_API_KEY=your_key_here npm run transcribe:local
+```
+
+This script (`local-audio-transcriber.js`) uses `ffmpeg` to read local audio input and streams PCM audio to AssemblyAI Streaming v3.
+
+### Optional environment variables
+
+```bash
+# defaults by OS: macOS=avfoundation, Linux=pulse, Windows=dshow
+AUDIO_INPUT_FORMAT=avfoundation
+
+# primary input device defaults by OS:
+# macOS=:0, Linux=default, Windows=audio=CABLE Output (VB-Audio Virtual Cable)
+AUDIO_INPUT_DEVICE=:0
+
+# optional secondary input mixed with primary (Windows default shown)
+# set empty to disable mixing
+AUDIO_INPUT_DEVICE_2=audio=Microphone (2- Realtek(R) Audio)
+
+# defaults to 16000
+AUDIO_SAMPLE_RATE=16000
+
+# defaults to universal-streaming-multilingual
+ASSEMBLYAI_SPEECH_MODEL=universal-streaming-multilingual
+```
+
+> Note: `ffmpeg` must be installed and available in your PATH.

--- a/backend/README.md
+++ b/backend/README.md
@@ -28,6 +28,7 @@ npm install
 ASSEMBLYAI_API_KEY=your_key_here npm start
 # optional
 # ASSEMBLYAI_SPEECH_MODEL=universal-streaming-multilingual npm start
+# ASSEMBLYAI_SPEAKER_LABELS=true ASSEMBLYAI_MAX_SPEAKERS=2 npm start
 ```
 
 The server listens on `ws://localhost:3001` (or `PORT` if set) and prints transcripts to stdout.
@@ -62,6 +63,12 @@ AUDIO_SAMPLE_RATE=16000
 
 # defaults to universal-streaming-multilingual
 ASSEMBLYAI_SPEECH_MODEL=universal-streaming-multilingual
+
+# defaults to true
+ASSEMBLYAI_SPEAKER_LABELS=true
+
+# optional diarization hint (1-10)
+ASSEMBLYAI_MAX_SPEAKERS=2
 ```
 
 > Note: `ffmpeg` must be installed and available in your PATH.

--- a/backend/local-audio-transcriber.js
+++ b/backend/local-audio-transcriber.js
@@ -16,10 +16,15 @@ const ffmpegFormat = process.env.AUDIO_INPUT_FORMAT || defaultInputFormat();
 const inputDevicePrimary = process.env.AUDIO_INPUT_DEVICE || defaultInputDevice();
 const inputDeviceSecondary = process.env.AUDIO_INPUT_DEVICE_2 || defaultSecondaryInputDevice();
 
+const enableSpeakerLabels = (process.env.ASSEMBLYAI_SPEAKER_LABELS || "true").toLowerCase() === "true";
+const maxSpeakers = process.env.ASSEMBLYAI_MAX_SPEAKERS ? Number(process.env.ASSEMBLYAI_MAX_SPEAKERS) : undefined;
+
 const client = new AssemblyAI({ apiKey });
 const transcriber = client.streaming.transcriber({
   sampleRate,
-  speechModel
+  speechModel,
+  speakerLabels: enableSpeakerLabels,
+  ...(Number.isInteger(maxSpeakers) ? { maxSpeakers } : {})
 });
 
 let ffmpegProcess;
@@ -39,7 +44,8 @@ transcriber.on("turn", (turn) => {
   const text = (turn.transcript || "").trim();
   if (!text) return;
   const tag = turn.end_of_turn ? "final" : "partial";
-  console.log(`[${tag}] ${text}`);
+  const speaker = turn.speaker_label || "UNKNOWN";
+  console.log(`[${tag}][${speaker}] ${text}`);
 });
 
 transcriber.on("error", (error) => {

--- a/backend/local-audio-transcriber.js
+++ b/backend/local-audio-transcriber.js
@@ -1,0 +1,140 @@
+import { spawn } from "node:child_process";
+import { AssemblyAI } from "assemblyai";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const apiKey = process.env.ASSEMBLYAI_API_KEY;
+if (!apiKey) {
+  console.error("Missing ASSEMBLYAI_API_KEY in environment.");
+  process.exit(1);
+}
+
+const speechModel = process.env.ASSEMBLYAI_SPEECH_MODEL || "universal-streaming-multilingual";
+const sampleRate = Number(process.env.AUDIO_SAMPLE_RATE || 16000);
+const ffmpegFormat = process.env.AUDIO_INPUT_FORMAT || defaultInputFormat();
+const inputDevicePrimary = process.env.AUDIO_INPUT_DEVICE || defaultInputDevice();
+const inputDeviceSecondary = process.env.AUDIO_INPUT_DEVICE_2 || defaultSecondaryInputDevice();
+
+const client = new AssemblyAI({ apiKey });
+const transcriber = client.streaming.transcriber({
+  sampleRate,
+  speechModel
+});
+
+let ffmpegProcess;
+let ready = false;
+const queuedChunks = [];
+
+transcriber.on("open", ({ id }) => {
+  ready = true;
+  console.log(`AssemblyAI session opened: ${id}`);
+
+  while (queuedChunks.length > 0) {
+    transcriber.sendAudio(queuedChunks.shift());
+  }
+});
+
+transcriber.on("turn", (turn) => {
+  const text = (turn.transcript || "").trim();
+  if (!text) return;
+  const tag = turn.end_of_turn ? "final" : "partial";
+  console.log(`[${tag}] ${text}`);
+});
+
+transcriber.on("error", (error) => {
+  console.error("AssemblyAI streaming error:", error?.message || error);
+});
+
+transcriber.on("close", (code, reason) => {
+  ready = false;
+  console.log("AssemblyAI streaming closed:", code, reason || "");
+});
+
+await transcriber.connect();
+console.log("Connected to AssemblyAI streaming API");
+console.log(
+  inputDeviceSecondary
+    ? `Starting audio capture via ffmpeg: ${inputDevicePrimary} + ${inputDeviceSecondary}`
+    : `Starting audio capture via ffmpeg: ${inputDevicePrimary}`
+);
+console.log("Press Ctrl+C to stop.\n");
+
+ffmpegProcess = spawn("ffmpeg", buildFfmpegArgs(), {
+  stdio: ["ignore", "pipe", "pipe"]
+});
+
+ffmpegProcess.stdout.on("data", (chunk) => {
+  if (ready) {
+    transcriber.sendAudio(chunk);
+  } else {
+    queuedChunks.push(chunk);
+  }
+});
+
+ffmpegProcess.stderr.on("data", (data) => {
+  const msg = data.toString().trim();
+  if (msg) console.error("ffmpeg:", msg);
+});
+
+ffmpegProcess.on("error", (error) => {
+  console.error("Failed to start ffmpeg. Is it installed and on PATH?", error.message);
+  shutdown(1);
+});
+
+ffmpegProcess.on("close", (code) => {
+  console.log(`ffmpeg process exited with code ${code}`);
+  shutdown(code === 0 ? 0 : 1);
+});
+
+process.on("SIGINT", () => shutdown(0));
+process.on("SIGTERM", () => shutdown(0));
+
+let shuttingDown = false;
+async function shutdown(exitCode) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  if (ffmpegProcess && !ffmpegProcess.killed) {
+    ffmpegProcess.kill("SIGTERM");
+  }
+
+  try {
+    await transcriber.close();
+  } catch (error) {
+    console.error("Error closing transcriber:", error?.message || error);
+  }
+
+  process.exit(exitCode);
+}
+
+function buildFfmpegArgs() {
+  const args = ["-hide_banner", "-loglevel", "error"];
+
+  args.push("-f", ffmpegFormat, "-i", inputDevicePrimary);
+
+  if (inputDeviceSecondary) {
+    args.push("-f", ffmpegFormat, "-i", inputDeviceSecondary);
+    args.push("-filter_complex", "[0:a][1:a]amix=inputs=2:duration=first:dropout_transition=2");
+  }
+
+  args.push("-ac", "1", "-ar", String(sampleRate), "-f", "s16le", "pipe:1");
+  return args;
+}
+
+function defaultInputFormat() {
+  if (process.platform === "darwin") return "avfoundation";
+  if (process.platform === "win32") return "dshow";
+  return "pulse";
+}
+
+function defaultInputDevice() {
+  if (process.platform === "darwin") return ":0";
+  if (process.platform === "win32") return "audio=CABLE Output (VB-Audio Virtual Cable)";
+  return "default";
+}
+
+function defaultSecondaryInputDevice() {
+  if (process.platform === "win32") return "audio=Microphone (2- Realtek(R) Audio)";
+  return "";
+}

--- a/backend/meeting-audio-backend.js
+++ b/backend/meeting-audio-backend.js
@@ -1,80 +1,119 @@
-import WebSocket, { WebSocketServer } from "ws";
+import { WebSocketServer, WebSocket } from "ws";
 import { AssemblyAI } from "assemblyai";
 import dotenv from "dotenv";
 
 dotenv.config();
 
-const client = new AssemblyAI({ apiKey: process.env.ASSEMBLYAI_API_KEY });
-const wss = new WebSocketServer({ port: 3001 });
+const port = Number(process.env.PORT || 3001);
+const apiKey = process.env.ASSEMBLYAI_API_KEY;
+
+if (!apiKey) {
+  console.error("Missing ASSEMBLYAI_API_KEY in environment.");
+  process.exit(1);
+}
+
+const client = new AssemblyAI({ apiKey });
+const wss = new WebSocketServer({ port });
 
 wss.on("connection", async (socket) => {
-  console.log("Client connected");
+  console.log("Extension connected.");
 
-  if (!process.env.ASSEMBLYAI_API_KEY) {
-    console.error("AssemblyAI API key not found in environment");
-    socket.close();
-    return;
-
-  }
-
-  let transcriber;
-  try {
-    transcriber = await client.realtime.transcriber({
-      sampleRate: 16000
-    });
-  } catch (error) {
-    console.error("Failed to create transcriber:", error);
-    socket.close();
-    return;
-  }
-
-  let isReady = false;
-  let buffer = [];
-
-  transcriber.on("open", () => {
-    console.log("Transcriber ready");
-    isReady = true;
-    buffer.forEach((chunk) => transcriber.sendAudio(chunk));
-    buffer = [];
+  // Use the v3 Streaming API (realtime/v2 returns HTTP 410 for many accounts).
+  const transcriber = client.streaming.transcriber({
+    sampleRate: 16000,
+    speechModel: process.env.ASSEMBLYAI_SPEECH_MODEL || "universal-streaming-multilingual"
   });
 
-  transcriber.on("transcript", (t) => {
-    if (t.text) {
-      console.log("Transcript:", t.text);
-      socket.send(JSON.stringify({ type: "TRANSCRIPT", text: t.text }));
+  let transcriberReady = false;
+  const audioBufferQueue = [];
+
+  transcriber.on("open", ({ id, expires_at: expiresAt }) => {
+    transcriberReady = true;
+    console.log("AssemblyAI streaming session open:", id, "expires_at:", expiresAt);
+
+    while (audioBufferQueue.length > 0) {
+      transcriber.sendAudio(audioBufferQueue.shift());
+    }
+  });
+
+  transcriber.on("turn", (turn) => {
+    const text = (turn.transcript || "").trim();
+    if (!text) return;
+
+    const transcriptType = turn.end_of_turn ? "final" : "partial";
+    console.log(`Transcript (${transcriptType}):`, text);
+
+    if (socket.readyState === WebSocket.OPEN) {
+      socket.send(
+        JSON.stringify({
+          type: "TRANSCRIPT",
+          text,
+          isFinal: Boolean(turn.end_of_turn)
+        })
+      );
     }
   });
 
   transcriber.on("error", (error) => {
-    console.error("Transcriber error:", error);
-    socket.send(JSON.stringify({ type: "ERROR", message: "Transcription error" }));
-  });
+    const message = error?.message || String(error);
+    console.error("AssemblyAI streaming error:", message);
 
-  socket.on("message", (audioChunk) => {
-    try {
-      // Handle both ArrayBuffer and Buffer
-      const audioData = Buffer.isBuffer(audioChunk) ? audioChunk : Buffer.from(audioChunk);
-      if (isReady) transcriber.sendAudio(audioData);
-      else buffer.push(audioData);
-    } catch (error) {
-      console.error("Error processing audio chunk:", error);
+    if (socket.readyState === WebSocket.OPEN) {
+      socket.send(
+        JSON.stringify({
+          type: "ERROR",
+          message: `AssemblyAI streaming error: ${message}`
+        })
+      );
     }
   });
 
-  socket.on("close", () => {
-    console.log("Client disconnected");
-    if (transcriber) {
-      try {
-        transcriber.close();
-      } catch (error) {
-        console.error("Error closing transcriber:", error);
-      }
+  transcriber.on("close", (code, reason) => {
+    transcriberReady = false;
+    console.log("AssemblyAI streaming closed:", code, reason || "");
+  });
+
+  try {
+    await transcriber.connect();
+  } catch (error) {
+    const message = error?.message || String(error);
+    console.error("Failed to connect to AssemblyAI streaming API:", message);
+
+    if (socket.readyState === WebSocket.OPEN) {
+      socket.send(
+        JSON.stringify({
+          type: "ERROR",
+          message: `Could not connect to AssemblyAI streaming API: ${message}`
+        })
+      );
+      socket.close();
+    }
+    return;
+  }
+
+  socket.on("message", (audioChunk) => {
+    const chunk = Buffer.isBuffer(audioChunk) ? audioChunk : Buffer.from(audioChunk);
+    if (!chunk.length) return;
+
+    if (transcriberReady) {
+      transcriber.sendAudio(chunk);
+    } else {
+      audioBufferQueue.push(chunk);
+    }
+  });
+
+  socket.on("close", async () => {
+    console.log("Extension disconnected.");
+    try {
+      await transcriber.close();
+    } catch (error) {
+      console.error("Error closing AssemblyAI streaming transcriber:", error);
     }
   });
 
   socket.on("error", (error) => {
-    console.error("WebSocket error:", error);
+    console.error("Extension websocket error:", error);
   });
 });
 
-console.log("Backend running on ws://localhost:3001");
+console.log(`Backend websocket server running at ws://localhost:${port}`);

--- a/backend/meeting-audio-backend.js
+++ b/backend/meeting-audio-backend.js
@@ -12,6 +12,9 @@ if (!apiKey) {
   process.exit(1);
 }
 
+const enableSpeakerLabels = (process.env.ASSEMBLYAI_SPEAKER_LABELS || "true").toLowerCase() === "true";
+const maxSpeakers = process.env.ASSEMBLYAI_MAX_SPEAKERS ? Number(process.env.ASSEMBLYAI_MAX_SPEAKERS) : undefined;
+
 const client = new AssemblyAI({ apiKey });
 const wss = new WebSocketServer({ port });
 
@@ -21,7 +24,9 @@ wss.on("connection", async (socket) => {
   // Use the v3 Streaming API (realtime/v2 returns HTTP 410 for many accounts).
   const transcriber = client.streaming.transcriber({
     sampleRate: 16000,
-    speechModel: process.env.ASSEMBLYAI_SPEECH_MODEL || "universal-streaming-multilingual"
+    speechModel: process.env.ASSEMBLYAI_SPEECH_MODEL || "universal-streaming-multilingual",
+    speakerLabels: enableSpeakerLabels,
+    ...(Number.isInteger(maxSpeakers) ? { maxSpeakers } : {})
   });
 
   let transcriberReady = false;
@@ -41,14 +46,16 @@ wss.on("connection", async (socket) => {
     if (!text) return;
 
     const transcriptType = turn.end_of_turn ? "final" : "partial";
-    console.log(`Transcript (${transcriptType}):`, text);
+    const speakerLabel = turn.speaker_label || "UNKNOWN";
+    console.log(`Transcript (${transcriptType}) [${speakerLabel}]:`, text);
 
     if (socket.readyState === WebSocket.OPEN) {
       socket.send(
         JSON.stringify({
           type: "TRANSCRIPT",
           text,
-          isFinal: Boolean(turn.end_of_turn)
+          isFinal: Boolean(turn.end_of_turn),
+          speakerLabel
         })
       );
     }

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "start": "node meeting-audio-backend.js"
+    "start": "node meeting-audio-backend.js",
+    "transcribe:local": "node local-audio-transcriber.js"
   },
   "dependencies": {
     "ws": "^8.14.0",

--- a/bot/meeting-audio-extension/background.js
+++ b/bot/meeting-audio-extension/background.js
@@ -1,125 +1,230 @@
+const EXTENSION_RUNTIME_VERSION = "1.1.0";
 let ws;
-let mediaStream;
-let audioContext;
-let processor;
 let isStreaming = false;
+let activeCaptureTabId = null;
+const OFFSCREEN_DOCUMENT_PATH = "offscreen.html";
 
-chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-  if (msg.action === "START") {
-    console.log("START received");
-    if (!isStreaming) {
-      startStreaming();
-    }
-  }
-  if (msg.action === "STOP") {
-    console.log("STOP received");
-    if (isStreaming) {
-      stopStreaming();
-    }
-  }
+chrome.runtime.onInstalled.addListener(() => {
+  console.log(`Live Transcriber extension installed (v${EXTENSION_RUNTIME_VERSION}).`);
 });
 
-function startStreaming() {
-  try {
-    ws = new WebSocket("ws://localhost:3001");
+console.log(`Live Transcriber background loaded (v${EXTENSION_RUNTIME_VERSION}).`);
 
-    ws.onopen = () => {
-      console.log("Connected to backend");
-      isStreaming = true;
-      chrome.runtime.sendMessage({ action: "STATUS", status: "Connected" });
-    };
-    
-    ws.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data);
-        if (data.type === "TRANSCRIPT") {
-          chrome.runtime.sendMessage(data);
-        } else if (data.type === "ERROR") {
-          chrome.runtime.sendMessage({ action: "ERROR", message: data.message });
-        }
-      } catch (error) {
-        console.error("Error parsing message from backend:", error);
-      }
-    };
-
-    ws.onerror = (error) => {
-      console.error("WebSocket error:", error);
-      chrome.runtime.sendMessage({ action: "ERROR", message: "Connection error" });
-      stopStreaming();
-    };
-
-    ws.onclose = () => {
-      console.log("WebSocket closed");
-      isStreaming = false;
-      chrome.runtime.sendMessage({ action: "STATUS", status: "Disconnected" });
-    };
-
-    // Capture tab audio
-    chrome.tabCapture.capture({ audio: true, video: false }).then(stream => {
-      if (!stream) {
-        throw new Error("Failed to capture audio");
-      }
-      
-      mediaStream = stream;
-      audioContext = new AudioContext({ sampleRate: 16000 });
-      const source = audioContext.createMediaStreamSource(mediaStream);
-
-      processor = audioContext.createScriptProcessor(4096, 1, 1);
-      source.connect(processor);
-      processor.connect(audioContext.destination);
-
-      processor.onaudioprocess = (e) => {
-        if (ws && ws.readyState === WebSocket.OPEN) {
-          const floatData = e.inputBuffer.getChannelData(0);
-          ws.send(floatTo16BitPCM(floatData));
-        }
-      };
-
-      chrome.runtime.sendMessage({ action: "STATUS", status: "Recording" });
-    }).catch(error => {
-      console.error("Error capturing audio:", error);
-      chrome.runtime.sendMessage({ action: "ERROR", message: "Failed to capture audio" });
-      stopStreaming();
-    });
-
-  } catch (error) {
-    console.error("Error starting streaming:", error);
-    chrome.runtime.sendMessage({ action: "ERROR", message: "Failed to start streaming" });
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message.action === "START") {
+    startStreaming(message.tabId)
+      .then(() => sendResponse({ ok: true }))
+      .catch((error) => {
+        sendStatusError(error.message || "Failed to start streaming");
+        sendResponse({ ok: false, message: error.message || "Failed to start streaming" });
+      });
+    return true;
   }
+
+  if (message.action === "STOP") {
+    stopStreaming();
+    sendResponse({ ok: true });
+    return true;
+  }
+
+  if (message.action === "GET_STATE") {
+    sendResponse({
+      ok: true,
+      isStreaming,
+      tabId: activeCaptureTabId
+    });
+    return true;
+  }
+
+  if (message.action === "AUDIO_CHUNK") {
+    if (ws && ws.readyState === WebSocket.OPEN && message.chunk) {
+      ws.send(message.chunk);
+    }
+    return false;
+  }
+
+  if (message.action === "CAPTURE_ERROR") {
+    sendStatusError(message.message || "Capture failed");
+    stopStreaming();
+    return false;
+  }
+
+  return false;
+});
+
+async function startStreaming(requestedTabId) {
+  if (isStreaming) {
+    throw new Error("Already streaming");
+  }
+
+  const tabId = Number.isInteger(requestedTabId) ? requestedTabId : await getActiveTabId();
+  if (!Number.isInteger(tabId)) {
+    throw new Error("Could not identify tab to capture.");
+  }
+
+  activeCaptureTabId = tabId;
+  sendStatus(`Connecting backend for tab ${tabId}...`);
+
+  ws = new WebSocket("ws://localhost:3001");
+
+  ws.onopen = () => {
+    sendStatus(`Backend connected (tab ${tabId})`);
+  };
+
+  ws.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      if (data.type === "TRANSCRIPT") {
+        chrome.runtime.sendMessage(data);
+      } else if (data.type === "ERROR") {
+        sendStatusError(data.message || "Backend transcription error");
+      }
+    } catch (error) {
+      console.error("Invalid backend message", error);
+    }
+  };
+
+  ws.onerror = () => {
+    sendStatusError("Could not connect to ws://localhost:3001");
+  };
+
+  ws.onclose = () => {
+    if (isStreaming) {
+      sendStatus("Disconnected");
+    }
+    isStreaming = false;
+    activeCaptureTabId = null;
+    void stopCaptureInOffscreen();
+  };
+
+  await waitForWebSocketOpen(ws);
+  await ensureOffscreenDocument();
+
+  const streamId = await getMediaStreamIdForTab(tabId);
+  const captureStartResult = await sendRuntimeMessage({
+    action: "START_CAPTURE",
+    streamId,
+    sampleRate: 16000
+  });
+
+  if (!captureStartResult?.ok) {
+    throw new Error(captureStartResult?.message || "Failed to start offscreen capture");
+  }
+
+  isStreaming = true;
+  sendStatus(`Recording tab ${tabId}. You can switch tabs or close popup.`);
 }
 
 function stopStreaming() {
-  console.log("Stopping streaming");
   isStreaming = false;
-  
-  if (processor) {
-    processor.disconnect();
-    processor = null;
-  }
-  if (audioContext) {
-    audioContext.close();
-    audioContext = null;
-  }
-  if (mediaStream) {
-    mediaStream.getTracks().forEach((t) => t.stop());
-    mediaStream = null;
-  }
+  void stopCaptureInOffscreen();
+
   if (ws) {
-    ws.close();
+    try {
+      ws.close();
+    } catch (error) {
+      console.error("Failed to close websocket", error);
+    }
     ws = null;
   }
-  
-  chrome.runtime.sendMessage({ action: "STATUS", status: "Stopped" });
+
+  activeCaptureTabId = null;
+  sendStatus("Stopped");
 }
 
-// Convert Float32 to PCM16
-function floatTo16BitPCM(float32Array) {
-  const buffer = new ArrayBuffer(float32Array.length * 2);
-  const view = new DataView(buffer);
-  let offset = 0;
-  for (let i = 0; i < float32Array.length; i++, offset += 2) {
-    let s = Math.max(-1, Math.min(1, float32Array[i]));
-    view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+async function stopCaptureInOffscreen() {
+  try {
+    await sendRuntimeMessage({ action: "STOP_CAPTURE" });
+  } catch {
+    // ignore when offscreen isn't up yet
   }
-  return buffer;
+}
+
+async function ensureOffscreenDocument() {
+  if (await chrome.offscreen.hasDocument()) {
+    return;
+  }
+
+  await chrome.offscreen.createDocument({
+    url: OFFSCREEN_DOCUMENT_PATH,
+    reasons: ["USER_MEDIA"],
+    justification: "Capture tab audio continuously while popup may be closed"
+  });
+}
+
+function getActiveTabId() {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+
+      resolve(tabs?.[0]?.id);
+    });
+  });
+}
+
+function getMediaStreamIdForTab(tabId) {
+  return new Promise((resolve, reject) => {
+    chrome.tabCapture.getMediaStreamId({ targetTabId: tabId }, (streamId) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+
+      if (!streamId) {
+        reject(new Error("Could not get media stream id for tab"));
+        return;
+      }
+
+      resolve(streamId);
+    });
+  });
+}
+
+function waitForWebSocketOpen(socket) {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error("Timed out connecting to backend"));
+    }, 5000);
+
+    socket.addEventListener(
+      "open",
+      () => {
+        clearTimeout(timeoutId);
+        resolve();
+      },
+      { once: true }
+    );
+
+    socket.addEventListener(
+      "error",
+      () => {
+        clearTimeout(timeoutId);
+        reject(new Error("Websocket connection failed"));
+      },
+      { once: true }
+    );
+  });
+}
+
+function sendRuntimeMessage(payload) {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage(payload, (response) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+      resolve(response);
+    });
+  });
+}
+
+function sendStatus(status) {
+  chrome.runtime.sendMessage({ action: "STATUS", status });
+}
+
+function sendStatusError(message) {
+  chrome.runtime.sendMessage({ action: "ERROR", message });
 }

--- a/bot/meeting-audio-extension/manifest.json
+++ b/bot/meeting-audio-extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Live Transcriber",
-  "version": "1.0",
-  "permissions": ["tabs", "tabCapture", "scripting"],
+  "version": "1.1.0",
+  "permissions": ["tabs", "tabCapture", "scripting", "offscreen"],
   "background": {
     "service_worker": "background.js"
   },

--- a/bot/meeting-audio-extension/offscreen.html
+++ b/bot/meeting-audio-extension/offscreen.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    <script src="offscreen.js"></script>
+  </body>
+</html>

--- a/bot/meeting-audio-extension/offscreen.js
+++ b/bot/meeting-audio-extension/offscreen.js
@@ -1,0 +1,86 @@
+let mediaStream;
+let audioContext;
+let processor;
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message.action === "START_CAPTURE") {
+    startCapture(message.streamId, message.sampleRate || 16000)
+      .then(() => sendResponse({ ok: true }))
+      .catch((error) => {
+        chrome.runtime.sendMessage({ action: "CAPTURE_ERROR", message: error.message || "Capture failed" });
+        sendResponse({ ok: false, message: error.message || "Capture failed" });
+      });
+    return true;
+  }
+
+  if (message.action === "STOP_CAPTURE") {
+    stopCapture();
+    sendResponse({ ok: true });
+    return false;
+  }
+
+  return false;
+});
+
+async function startCapture(streamId, sampleRate) {
+  if (!streamId) {
+    throw new Error("Missing stream ID for capture");
+  }
+
+  stopCapture();
+
+  mediaStream = await navigator.mediaDevices.getUserMedia({
+    audio: {
+      mandatory: {
+        chromeMediaSource: "tab",
+        chromeMediaSourceId: streamId
+      }
+    },
+    video: false
+  });
+
+  audioContext = new AudioContext({ sampleRate });
+  const source = audioContext.createMediaStreamSource(mediaStream);
+  processor = audioContext.createScriptProcessor(4096, 1, 1);
+
+  source.connect(processor);
+  processor.connect(audioContext.destination);
+
+  processor.onaudioprocess = (event) => {
+    const floatData = event.inputBuffer.getChannelData(0);
+    chrome.runtime.sendMessage({ action: "AUDIO_CHUNK", chunk: floatTo16BitPCM(floatData) });
+  };
+}
+
+function stopCapture() {
+  if (processor) {
+    try {
+      processor.disconnect();
+    } catch (error) {
+      console.error("Failed to disconnect processor", error);
+    }
+    processor = null;
+  }
+
+  if (audioContext) {
+    audioContext.close().catch(() => {});
+    audioContext = null;
+  }
+
+  if (mediaStream) {
+    mediaStream.getTracks().forEach((track) => track.stop());
+    mediaStream = null;
+  }
+}
+
+function floatTo16BitPCM(float32Array) {
+  const buffer = new ArrayBuffer(float32Array.length * 2);
+  const view = new DataView(buffer);
+
+  for (let i = 0; i < float32Array.length; i += 1) {
+    const sample = Math.max(-1, Math.min(1, float32Array[i]));
+    view.setInt16(i * 2, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+  }
+
+  return buffer;
+}

--- a/bot/meeting-audio-extension/popup.html
+++ b/bot/meeting-audio-extension/popup.html
@@ -3,7 +3,7 @@
   <head>
     <style>
       body {
-        width: 200px;
+        width: 260px;
         padding: 10px;
         font-family: Arial, sans-serif;
       }
@@ -16,27 +16,34 @@
         cursor: pointer;
         font-size: 14px;
       }
-      #start {
-        background-color: #4CAF50;
+      #startBtn {
+        background-color: #4caf50;
         color: white;
       }
-      #stop {
+      #stopBtn {
         background-color: #f44336;
         color: white;
       }
-      #stop:disabled {
+      #stopBtn:disabled,
+      #startBtn:disabled {
         background-color: #cccccc;
         cursor: not-allowed;
       }
-      #start:disabled {
-        background-color: #cccccc;
-        cursor: not-allowed;
-      }
-      .status {
+      #status {
         text-align: center;
         margin: 10px 0;
         font-size: 12px;
         color: #666;
+      }
+      #transcripts {
+        margin-top: 8px;
+        max-height: 180px;
+        overflow: auto;
+        font-size: 12px;
+        background: #f7f7f7;
+        padding: 8px;
+        border-radius: 4px;
+        white-space: pre-wrap;
       }
     </style>
   </head>

--- a/bot/meeting-audio-extension/popup.js
+++ b/bot/meeting-audio-extension/popup.js
@@ -1,62 +1,111 @@
-document.addEventListener('DOMContentLoaded', function() {
-  const startBtn = document.getElementById("startBtn");
-  const stopBtn = document.getElementById("stopBtn");
-  const transcripts = document.getElementById("transcripts");
-  const status = document.getElementById("status");
+const EXTENSION_RUNTIME_VERSION = "1.1.0";
+const startBtn = document.getElementById("startBtn");
+const stopBtn = document.getElementById("stopBtn");
+const transcripts = document.getElementById("transcripts");
+const status = document.getElementById("status");
 
-  let isStreaming = false;
+let isStreaming = false;
 
-  // Initialize button states
+initialize();
+
+async function initialize() {
   stopBtn.disabled = true;
   status.textContent = "Ready to start";
+  console.log(`[Live Transcriber ${EXTENSION_RUNTIME_VERSION}] popup initialized`);
 
-  startBtn.onclick = () => {
-    if (!isStreaming) {
-      console.log("Start button clicked");
-      startBtn.disabled = true;
-      status.textContent = "Starting...";
-      chrome.runtime.sendMessage({ action: "START" });
-    }
-  };
-  
-  stopBtn.onclick = () => {
-    if (isStreaming) {
-      console.log("Stop button clicked");
-      stopBtn.disabled = true;
-      status.textContent = "Stopping...";
-      chrome.runtime.sendMessage({ action: "STOP" });
-    }
-  };
-
-  // Listen for messages from background
-  chrome.runtime.onMessage.addListener((msg) => {
-    console.log("Message received:", msg);
-    
-    if (msg.type === "TRANSCRIPT") {
-      transcripts.textContent += msg.text + "\n";
-      // Auto-scroll to bottom
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message.type === "TRANSCRIPT" && message.text) {
+      const prefix = message.isFinal ? "" : "… ";
+      transcripts.textContent += `${prefix}${message.text}\n`;
       transcripts.scrollTop = transcripts.scrollHeight;
-    } else if (msg.action === "STATUS") {
-      status.textContent = msg.status;
-      
-      if (msg.status === "Recording") {
-        isStreaming = true;
-        startBtn.disabled = true;
-        stopBtn.disabled = false;
-      } else if (msg.status === "Stopped" || msg.status === "Disconnected") {
-        isStreaming = false;
-        startBtn.disabled = false;
-        stopBtn.disabled = true;
+      return;
+    }
+
+    if (message.action === "STATUS") {
+      status.textContent = message.status;
+      const currentlyRecording = typeof message.status === "string" && message.status.startsWith("Recording");
+      isStreaming = currentlyRecording;
+      startBtn.disabled = currentlyRecording;
+      stopBtn.disabled = !currentlyRecording;
+      return;
+    }
+
+    if (message.action === "ERROR") {
+      const rawMessage = message.message || "Unknown error";
+      if (rawMessage.includes("tabCapture.capture is not a function")) {
+        status.textContent = "Error: Extension runtime is stale. Please reload extension in chrome://extensions and try again.";
+      } else {
+        status.textContent = `Error: ${rawMessage}`;
       }
-    } else if (msg.action === "ERROR") {
-      status.textContent = "Error: " + msg.message;
-      console.error("Extension error:", msg.message);
       isStreaming = false;
       startBtn.disabled = false;
       stopBtn.disabled = true;
     }
   });
 
-  // Handle any runtime errors
-  chrome.runtime.lastError && console.error("Runtime error:", chrome.runtime.lastError);
-});
+  try {
+    const state = await sendMessage({ action: "GET_STATE" });
+    if (state?.ok && state.isStreaming) {
+      isStreaming = true;
+      startBtn.disabled = true;
+      stopBtn.disabled = false;
+      status.textContent = `Recording tab ${state.tabId ?? ""}`.trim();
+    }
+  } catch (error) {
+    status.textContent = `Error: ${error.message}`;
+  }
+
+  startBtn.addEventListener("click", async () => {
+    if (isStreaming) return;
+
+    startBtn.disabled = true;
+    status.textContent = "Starting...";
+
+    try {
+      const tabId = await getActiveTabId();
+      const response = await sendMessage({ action: "START", tabId });
+      if (!response?.ok) {
+        throw new Error(response?.message || "Failed to start streaming");
+      }
+    } catch (error) {
+      status.textContent = `Error: ${error.message}`;
+      startBtn.disabled = false;
+      stopBtn.disabled = true;
+    }
+  });
+
+  stopBtn.addEventListener("click", async () => {
+    if (!isStreaming) return;
+
+    await sendMessage({ action: "STOP" });
+    isStreaming = false;
+    status.textContent = "Stopped";
+    startBtn.disabled = false;
+    stopBtn.disabled = true;
+  });
+}
+
+function getActiveTabId() {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+
+      resolve(tabs?.[0]?.id);
+    });
+  });
+}
+
+function sendMessage(payload) {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage(payload, (response) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+      resolve(response);
+    });
+  });
+}

--- a/bot/meeting-audio-extension/popup.js
+++ b/bot/meeting-audio-extension/popup.js
@@ -16,7 +16,8 @@ async function initialize() {
   chrome.runtime.onMessage.addListener((message) => {
     if (message.type === "TRANSCRIPT" && message.text) {
       const prefix = message.isFinal ? "" : "… ";
-      transcripts.textContent += `${prefix}${message.text}\n`;
+      const speaker = message.speakerLabel || "UNKNOWN";
+      transcripts.textContent += `${prefix}[${speaker}] ${message.text}\n`;
       transcripts.scrollTop = transcripts.scrollHeight;
       return;
     }


### PR DESCRIPTION
### Motivation

- Provide a robust local backend for live meeting transcription using AssemblyAI Streaming v3 and a Node-only local transcriber for direct audio input.
- Improve the Chrome extension to capture tab audio reliably while the popup is closed by using an offscreen document and more resilient websocket handling.
- Make the extension UI and runtime more informative and resilient to errors and stale runtimes.

### Description

- Added `local-audio-transcriber.js` which streams local audio to AssemblyAI using `ffmpeg` and the AssemblyAI streaming client, with configurable environment variables like `ASSEMBLYAI_API_KEY`, `AUDIO_SAMPLE_RATE`, and `AUDIO_INPUT_DEVICE`.
- Enhanced `meeting-audio-backend.js` to validate `ASSEMBLYAI_API_KEY`, use the v3 streaming API, queue audio before the session is ready, surface structured `TRANSCRIPT` and `ERROR` messages, and support configurable `PORT`.
- Added `transcribe:local` npm script and updated `start` in `backend/package.json`.
- Reworked the extension background (`background.js`) to v1.1.0: use an offscreen document for continuous tab audio capture, manage websocket lifecycle and buffering, handle connection errors, and expose `START`/`STOP`/`GET_STATE` RPC-style messages.
- Added offscreen capture files `offscreen.html` and `offscreen.js` that obtain a tab `streamId`, create an `AudioContext`, convert audio to 16-bit PCM, and forward chunks back to the background script.
- Updated extension UI: increased popup width, renamed buttons, added transcripts container, and revamped `popup.js` to initialize state, interact with the background via promises, show live partial/final transcripts, and handle errors and restart logic.
- Updated `manifest.json` to `version: 1.1.0` and added the `offscreen` permission.
- Improved logging, error messages, and safe shutdown/cleanup behavior across backend and extension code.

### Testing

- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac9483b01c83218a4cf3312ed1b30f)