### PR TITLE
Switch local transcription flow from AssemblyAI to ElevenLabs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -18,17 +18,17 @@ IssueStatus JSON matching `shared/schemas/issue_status.json`
 
 ## Local meeting transcription websocket
 
-A lightweight local websocket server is available at `backend/meeting-audio-backend.js` for extension-driven live transcription with AssemblyAI Streaming (v3 websocket API).
+A lightweight local websocket server is available at `backend/meeting-audio-backend.js` for extension-driven live transcription with ElevenLabs Speech-to-Text (chunked via local ffmpeg capture).
 
 ### Run
 
 ```bash
 cd backend
 npm install
-ASSEMBLYAI_API_KEY=your_key_here npm start
+ELEVENLABS_API_KEY=your_key_here npm start
 # optional
-# ASSEMBLYAI_SPEECH_MODEL=universal-streaming-multilingual npm start
-# ASSEMBLYAI_SPEAKER_LABELS=true ASSEMBLYAI_MAX_SPEAKERS=2 npm start
+# ELEVENLABS_MODEL_ID=scribe_v1 npm start
+# TRANSCRIPTION_CHUNK_MS=5000 npm start
 ```
 
 The server listens on `ws://localhost:3001` (or `PORT` if set) and prints transcripts to stdout.
@@ -39,10 +39,10 @@ If you want to drop the extension and transcribe directly from local audio input
 
 ```bash
 cd backend
-ASSEMBLYAI_API_KEY=your_key_here npm run transcribe:local
+ELEVENLABS_API_KEY=your_key_here npm run transcribe:local
 ```
 
-This script (`local-audio-transcriber.js`) uses `ffmpeg` to read local audio input and streams PCM audio to AssemblyAI Streaming v3.
+This script (`local-audio-transcriber.js`) uses `ffmpeg` to read local audio input and chunks PCM audio and sends each chunk to ElevenLabs Speech-to-Text.
 
 ### Optional environment variables
 
@@ -61,14 +61,14 @@ AUDIO_INPUT_DEVICE_2=audio=Microphone (2- Realtek(R) Audio)
 # defaults to 16000
 AUDIO_SAMPLE_RATE=16000
 
-# defaults to universal-streaming-multilingual
-ASSEMBLYAI_SPEECH_MODEL=universal-streaming-multilingual
+# defaults to scribe_v1
+ELEVENLABS_MODEL_ID=scribe_v1
 
-# defaults to true
-ASSEMBLYAI_SPEAKER_LABELS=true
+# optional language hint (example: en)
+ELEVENLABS_LANGUAGE_CODE=en
 
-# optional diarization hint (1-10)
-ASSEMBLYAI_MAX_SPEAKERS=2
+# defaults to 5000 (5s chunks)
+TRANSCRIPTION_CHUNK_MS=5000
 ```
 
 > Note: `ffmpeg` must be installed and available in your PATH.

--- a/transcription/README.md
+++ b/transcription/README.md
@@ -15,5 +15,5 @@ JSON files written to `data/transcripts/` (or equivalent) matching the Transcrip
 ```
 
 ## Key Decisions
-- Whisper (local) vs Deepgram vs AssemblyAI
+- Whisper (local) vs Deepgram vs ElevenLabs
 - How to handle speaker diarization

--- a/transcription/local-audio-transcriber.js
+++ b/transcription/local-audio-transcriber.js
@@ -1,69 +1,37 @@
 import { spawn } from "node:child_process";
-import { AssemblyAI } from "assemblyai";
 import dotenv from "dotenv";
 
 dotenv.config();
 
-const apiKey = process.env.ASSEMBLYAI_API_KEY;
+const apiKey = process.env.ELEVENLABS_API_KEY;
 if (!apiKey) {
-  console.error("Missing ASSEMBLYAI_API_KEY in environment.");
+  console.error("Missing ELEVENLABS_API_KEY in environment.");
   process.exit(1);
 }
 
-const speechModel = process.env.ASSEMBLYAI_SPEECH_MODEL || "u3-rt-pro";
+const modelId = process.env.ELEVENLABS_MODEL_ID || "scribe_v1";
+const languageCode = process.env.ELEVENLABS_LANGUAGE_CODE;
 const sampleRate = Number(process.env.AUDIO_SAMPLE_RATE || 16000);
+const chunkDurationMs = Number(process.env.TRANSCRIPTION_CHUNK_MS || 5000);
 const ffmpegFormat = process.env.AUDIO_INPUT_FORMAT || defaultInputFormat();
 const inputDevicePrimary = process.env.AUDIO_INPUT_DEVICE || defaultInputDevice();
 const inputDeviceSecondary = process.env.AUDIO_INPUT_DEVICE_2 || defaultSecondaryInputDevice();
 
-const enableSpeakerLabels = (process.env.ASSEMBLYAI_SPEAKER_LABELS || "true").toLowerCase() === "true";
-const maxSpeakers = process.env.ASSEMBLYAI_MAX_SPEAKERS ? Number(process.env.ASSEMBLYAI_MAX_SPEAKERS) : undefined;
-
-const client = new AssemblyAI({ apiKey });
-const transcriber = client.streaming.transcriber({
-  sampleRate,
-  speechModel,
-  speakerLabels: enableSpeakerLabels,
-  ...(Number.isInteger(maxSpeakers) ? { maxSpeakers } : {})
-});
-
 let ffmpegProcess;
-let ready = false;
-const queuedChunks = [];
+let pendingAudio = Buffer.alloc(0);
+let chunkIndex = 0;
+const bytesPerSecond = sampleRate * 2;
+const chunkSizeBytes = Math.max(1, Math.floor((bytesPerSecond * chunkDurationMs) / 1000));
 
-transcriber.on("open", ({ id }) => {
-  ready = true;
-  console.log(`AssemblyAI session opened: ${id}`);
+let processingQueue = Promise.resolve();
 
-  while (queuedChunks.length > 0) {
-    transcriber.sendAudio(queuedChunks.shift());
-  }
-});
-
-transcriber.on("turn", (turn) => {
-  const text = (turn.transcript || "").trim();
-  if (!text) return;
-  const tag = turn.end_of_turn ? "final" : "partial";
-  const speaker = turn.speaker_label || "UNKNOWN";
-  console.log(`[${tag}][${speaker}] ${text}`);
-});
-
-transcriber.on("error", (error) => {
-  console.error("AssemblyAI streaming error:", error?.message || error);
-});
-
-transcriber.on("close", (code, reason) => {
-  ready = false;
-  console.log("AssemblyAI streaming closed:", code, reason || "");
-});
-
-await transcriber.connect();
-console.log("Connected to AssemblyAI streaming API");
 console.log(
   inputDeviceSecondary
     ? `Starting audio capture via ffmpeg: ${inputDevicePrimary} + ${inputDeviceSecondary}`
     : `Starting audio capture via ffmpeg: ${inputDevicePrimary}`
 );
+console.log(`Using ElevenLabs model: ${modelId}`);
+console.log(`Chunk duration: ${chunkDurationMs}ms`);
 console.log("Press Ctrl+C to stop.\n");
 
 ffmpegProcess = spawn("ffmpeg", buildFfmpegArgs(), {
@@ -71,10 +39,11 @@ ffmpegProcess = spawn("ffmpeg", buildFfmpegArgs(), {
 });
 
 ffmpegProcess.stdout.on("data", (chunk) => {
-  if (ready) {
-    transcriber.sendAudio(chunk);
-  } else {
-    queuedChunks.push(chunk);
+  pendingAudio = Buffer.concat([pendingAudio, chunk]);
+  while (pendingAudio.length >= chunkSizeBytes) {
+    const audioSlice = pendingAudio.subarray(0, chunkSizeBytes);
+    pendingAudio = pendingAudio.subarray(chunkSizeBytes);
+    queueTranscription(audioSlice, false);
   }
 });
 
@@ -96,6 +65,46 @@ ffmpegProcess.on("close", (code) => {
 process.on("SIGINT", () => shutdown(0));
 process.on("SIGTERM", () => shutdown(0));
 
+function queueTranscription(audioBuffer, flush) {
+  const currentChunk = ++chunkIndex;
+  processingQueue = processingQueue.then(() => transcribeChunk(audioBuffer, currentChunk, flush));
+}
+
+async function transcribeChunk(audioBuffer, currentChunk, flush) {
+  try {
+    const wavBuffer = pcm16MonoToWav(audioBuffer, sampleRate);
+    const form = new FormData();
+    form.append("model_id", modelId);
+    if (languageCode) {
+      form.append("language_code", languageCode);
+    }
+    form.append("file", new Blob([wavBuffer], { type: "audio/wav" }), `chunk-${currentChunk}.wav`);
+
+    const response = await fetch("https://api.elevenlabs.io/v1/speech-to-text", {
+      method: "POST",
+      headers: {
+        "xi-api-key": apiKey
+      },
+      body: form
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      console.error(`ElevenLabs transcription failed for chunk ${currentChunk}:`, response.status, errorBody);
+      return;
+    }
+
+    const payload = await response.json();
+    const text = (payload.text || "").trim();
+    if (!text) return;
+
+    const tag = flush ? "final" : "partial";
+    console.log(`[${tag}][UNKNOWN] ${text}`);
+  } catch (error) {
+    console.error(`Error transcribing chunk ${currentChunk}:`, error?.message || error);
+  }
+}
+
 let shuttingDown = false;
 async function shutdown(exitCode) {
   if (shuttingDown) return;
@@ -105,10 +114,15 @@ async function shutdown(exitCode) {
     ffmpegProcess.kill("SIGTERM");
   }
 
+  if (pendingAudio.length > 0) {
+    queueTranscription(pendingAudio, true);
+    pendingAudio = Buffer.alloc(0);
+  }
+
   try {
-    await transcriber.close();
+    await processingQueue;
   } catch (error) {
-    console.error("Error closing transcriber:", error?.message || error);
+    console.error("Error while draining transcription queue:", error?.message || error);
   }
 
   process.exit(exitCode);
@@ -126,6 +140,27 @@ function buildFfmpegArgs() {
 
   args.push("-ac", "1", "-ar", String(sampleRate), "-f", "s16le", "pipe:1");
   return args;
+}
+
+function pcm16MonoToWav(pcmData, hz) {
+  const header = Buffer.alloc(44);
+  const dataSize = pcmData.length;
+
+  header.write("RIFF", 0);
+  header.writeUInt32LE(36 + dataSize, 4);
+  header.write("WAVE", 8);
+  header.write("fmt ", 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(1, 22);
+  header.writeUInt32LE(hz, 24);
+  header.writeUInt32LE(hz * 2, 28);
+  header.writeUInt16LE(2, 32);
+  header.writeUInt16LE(16, 34);
+  header.write("data", 36);
+  header.writeUInt32LE(dataSize, 40);
+
+  return Buffer.concat([header, pcmData]);
 }
 
 function defaultInputFormat() {

--- a/transcription/package-lock.json
+++ b/transcription/package-lock.json
@@ -8,21 +8,8 @@
       "name": "meeting-audio-backend",
       "version": "1.0.0",
       "dependencies": {
-        "assemblyai": "^4.0.0",
         "dotenv": "^16.3.1",
         "ws": "^8.14.0"
-      }
-    },
-    "node_modules/assemblyai": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/assemblyai/-/assemblyai-4.26.1.tgz",
-      "integrity": "sha512-ORD3JnoouwH1N0Dr/oURElR+0evUCcNrGuS6kDNEkDWu7QFu7dPskuPTRq0HKaHmGYhNIqNwFn23BychkpY7Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/dotenv": {

--- a/transcription/package.json
+++ b/transcription/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "ws": "^8.14.0",
-    "assemblyai": "^4.0.0",
     "dotenv": "^16.3.1"
   }
 }


### PR DESCRIPTION
### Motivation
- Replace AssemblyAI streaming with ElevenLabs Speech-to-Text for local transcription to enable chunked uploads and simplify the local transcriber flow. 
- Update configuration and documentation to reflect the new provider and expose chunk sizing controls for robustness on variable network/latency conditions.

### Description
- Replaced `transcription/local-audio-transcriber.js` implementation to remove the AssemblyAI client and instead capture PCM audio from `ffmpeg`, chunk it, wrap chunks as WAV, and POST each chunk to ElevenLabs `/v1/speech-to-text` with sequential queueing and flush-on-shutdown behavior. 
- Swapped environment variables and defaults to use `ELEVENLABS_API_KEY`, `ELEVENLABS_MODEL_ID` (default `scribe_v1`), optional `ELEVENLABS_LANGUAGE_CODE`, and `TRANSCRIPTION_CHUNK_MS` (default `5000`).
- Removed the `assemblyai` dependency from `transcription/package.json` and pruned corresponding entries in `transcription/package-lock.json`.
- Updated docs in `backend/README.md` and `transcription/README.md` to describe ElevenLabs usage, new env vars, and chunked local transcription behavior.

### Testing
- Ran `node --check transcription/local-audio-transcriber.js` and it completed successfully. 
- Attempted to run `npm install` in `transcription/` but the install failed due to a network/registry permission error (`403 Forbidden`), so the lockfile was edited to remove `assemblyai` entries but could not be fully regenerated in this environment. 
- Verified updated docs render text changes and validated the transcriber script compiles under Node (no runtime integration tests were run due to environment network constraints).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf518f6a08321b84309d6de2fa620)